### PR TITLE
patch: Calculator task when using multiple workers

### DIFF
--- a/internal/calculation.go
+++ b/internal/calculation.go
@@ -20,9 +20,18 @@ type Conversor interface {
 // It receives a channel with the transactions and sends the flatten entities to the output channel.
 func Calculate(ctx context.Context, conversor Conversor, input <-chan entities.Transaction, output chan<- entities.Flatten) error {
 	for {
-		transaction, ok := <-input
-		if !ok {
-			break
+		var (
+			transaction entities.Transaction
+			ok          bool
+		)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case transaction, ok = <-input:
+			if !ok {
+				return nil
+			}
 		}
 
 		date := transaction.TS.Format("2006-01-02")
@@ -46,6 +55,4 @@ func Calculate(ctx context.Context, conversor Conversor, input <-chan entities.T
 			TotalVolume: valueUSD,
 		}
 	}
-
-	return nil
 }

--- a/internal/pipeline.go
+++ b/internal/pipeline.go
@@ -215,20 +215,18 @@ func (p *Pipeline) runCalculation(ctx context.Context, g *errgroup.Group, transa
 	}
 
 	var (
-		fs       = make(chan entities.Flatten, chanCap)
-		fsClosed bool
+		fs = make(chan entities.Flatten, chanCap)
 
 		fsSm sync.Mutex
+		cgo  = p.cfg.Workers
 	)
 
 	for range p.cfg.Workers {
 		g.Go(func() error {
 			defer func() {
 				fsSm.Lock()
-				if !fsClosed {
+				if cgo--; cgo == 0 {
 					close(fs)
-
-					fsClosed = true
 				}
 				fsSm.Unlock()
 			}()


### PR DESCRIPTION
# Description

Fixed Calculator task when running with multiple workers due to sending thro a closed channel.

The issue was that the first routine that finished, was closing the channel, but other routines were not finished.

Changed to last out, closed the door.